### PR TITLE
Remove obsolte polyfills

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,10 @@
-import 'fast-text-encoding';
 import baseX from 'base-x';
-import { Buffer } from 'buffer/';
 
 const BASE_36_CHARSET = '0123456789abcdefghijklmnopqrstuvwxyz';
-
 const base36 = baseX(BASE_36_CHARSET);
 
 export function encode(text: string): string {
-  return base36.encode(Buffer.from(new TextEncoder().encode(text)));
+  return base36.encode(new TextEncoder().encode(text));
 }
 
 export function decode(base36string: string): string {


### PR DESCRIPTION
There is now broad browser (and nodejs) support for [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) which should let us remove some polyfills. 

Buffer, in particular, is pretty big at ~57k unminified.

I don't think there's any reason not to remove it.